### PR TITLE
Reconfigure 'eslint-simple-import-sort' plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,8 +24,8 @@ export default tseslint.config([
             // 2) Packages (node_modules)
             ['^@?\\w'],
 
-            // 3) Absolute aliases (e.g. @ or src/)
-            ['^(@|src)(/.*|$)'],
+            // 3) Absolute aliases except 'assets'
+            ['^(?:@|src)/(?!assets/)'],
 
             // 4) Side-effect imports (e.g. polyfills, CSS resets)
             ['^\\u0000'],
@@ -36,6 +36,9 @@ export default tseslint.config([
 
             // 6) Styles
             ['^.+\\.s?css$'],
+
+            // 7) Images inside 'assets'
+            ['^(?:@|src)/assets/.*\\.(?:avif|bmp|gif|jpe?g|png|svg|webp)$'],
           ],
         },
       ],


### PR DESCRIPTION
### Please verify that:

- [x] `bun run dev` run

### :pencil: Description

Reconfiguring 'eslint-simple-import-sort' plugin to push static assets when importing to the bottom of import statements.